### PR TITLE
Add NoTenants option to disable per-tenant metrics in

### DIFF
--- a/plugins/base.py
+++ b/plugins/base.py
@@ -43,6 +43,7 @@ class Base(object):
         self.debug = False
         self.prefix = ''
         self.interval = 60.0
+        self.notenants = False
 
     def get_keystone(self):
         """Returns a Keystone.Client instance."""
@@ -82,6 +83,8 @@ class Base(object):
                 self.prefix = node.values[0]
             elif node.key == 'Interval':
                 self.interval = float(node.values[0])
+            elif node.key == 'NoTenants':
+                self.notenants = True
             else:
                 collectd.warning("%s: unknown config key: %s" % (self.prefix, node.key))
 

--- a/plugins/keystone_plugin.py
+++ b/plugins/keystone_plugin.py
@@ -54,19 +54,20 @@ class KeystonePlugin(base.Base):
                 'count': len(keystone.__getattribute__(item).list())
             }
 
-        # User count per tenant
-        tenant_list = keystone.tenants.list()
-        for tenant in tenant_list:
-            data[self.prefix]["tenant-%s" % tenant.name] = { 'users': {} }
-            data_tenant = data[self.prefix]["tenant-%s" % tenant.name]
-            data_tenant['users']['count'] = len(keystone.tenants.list_users(tenant.id))
+        if getattr(self, 'notenants') == False:
+            # User count per tenant
+            tenant_list = keystone.tenants.list()
+            for tenant in tenant_list:
+                data[self.prefix]["tenant-%s" % tenant.name] = { 'users': {} }
+                data_tenant = data[self.prefix]["tenant-%s" % tenant.name]
+                data_tenant['users']['count'] = len(keystone.tenants.list_users(tenant.id))
 
         return data
 
 try:
     plugin = KeystonePlugin()
 except Exception as exc:
-    collectd.error("openstack-keystone: failed to initialize glance plugin :: %s :: %s"
+    collectd.error("openstack-keystone: failed to initialize keystone plugin :: %s :: %s"
             % (exc, traceback.format_exc()))
     
 def configure_callback(conf):


### PR DESCRIPTION
keystone and nova plugins.

Use case:  Our environment has thousands of tenants, and sending all those metrics to our Graphite system would quickly overwhelm it.  But we do want the global total and per-hypervisor data.
